### PR TITLE
Improve UX by making the game always ready

### DIFF
--- a/src/components/Menu/MenuButtons/MenuButtons.vue
+++ b/src/components/Menu/MenuButtons/MenuButtons.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="menu-buttons">
-    <button type="button" class="btn btn--lg" id="start-game" v-bind:disabled="startDisabled" v-on:click="startGame">
+    <button type="button" class="btn btn--lg" id="start-game" v-on:click="startGame">
       Spiel Starten
     </button>
     <button type="button" class="btn btn--lg" id="show-highscores" v-on:click="showHighscores">
@@ -12,12 +12,6 @@
 <script>
   export default {
     name: 'MenuButtons',
-    computed: {
-      startDisabled () {
-        if (this.$store.state.gameReady) console.log('Game ready');
-        return !this.$store.state.gameReady;
-      }
-    },
     methods: {
       startGame () {
         this.$store.commit('startCountdown');

--- a/src/components/Menu/PlayerForm/PlayerForm.vue
+++ b/src/components/Menu/PlayerForm/PlayerForm.vue
@@ -3,7 +3,7 @@
     <div class="form__group">
       <label for="player-name" class="player-form__label">Gib deinen Namen ein:</label>
       <input type="text" class="form__input player-form__input" id="player-name" name="player-name"
-        maxlength="30" @keyup="processInput">
+        maxlength="30" placeholder="Spieler 1" @keyup="processName">
     </div>
   </div>
 </template>
@@ -12,7 +12,7 @@
   export default {
     name: 'PlayerForm',
     methods: {
-      processInput (e) {
+      processName (e) {
         if (e.target.value.length > 0) {
           this.$store.commit('playerReady', e.target.value);
         } else {

--- a/src/components/Store.js
+++ b/src/components/Store.js
@@ -13,14 +13,9 @@ const store = new Vuex.Store({
     gameInitText: 'Mach dich bereit!',
 
     // General game data
-    playerName: '',
+    playerName: 'Spieler 1',
     selectedCategory: 'animals',
     availableCards: {},
-
-    // Menu states
-    playerReady: false,
-    categoryReady: true,
-    gameReady: false,
 
     // App states
     showGamePanel: false,
@@ -41,16 +36,9 @@ const store = new Vuex.Store({
     // Menu mutations
     playerReady (state, playername) {
       state.playerName = playername;
-      state.gameReady = state.categoryReady;
     },
     playerNotReady (state) {
-      state.gameReady = state.playerReady = false;
-    },
-    categoryReady (state) {
-      state.gameReady = state.playerReady;
-    },
-    categoryNotReady (state) {
-      state.gameReady = state.categoryReady = false;
+      state.playerName = "Spieler 1"
     },
     selectCategory (state, newCategory) {
       state.selectedCategory = newCategory;


### PR DESCRIPTION
It is a bit annoying to have to enter the player name everytime, it is best to assume default values and make the game playable from the start. 

Additionally CategoryReady and CategoryNotReady are deleted because they are never used